### PR TITLE
Fix gene encoding prototypes and link math library

### DIFF
--- a/src/C/Makefile
+++ b/src/C/Makefile
@@ -15,7 +15,7 @@ OBJS = $(SRCS:.c=.o)
 
 # Rule to link object files to create target executable
 $(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS)
+	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS) -lm
 
 # Rule to compile source files to object files
 .c.o:

--- a/src/C/gene_encoding.h
+++ b/src/C/gene_encoding.h
@@ -43,7 +43,7 @@ uint8_t get_output_type(const Gene* gene);
 uint16_t get_destination_neuron_id(const Gene* gene);
 float get_weight(const Gene* gene);
 uint8_t get_activation_function(const Gene* gene);
-void get_source_num_corresponding_neurons_and_offset(const Gene* gene, u_int16_t* num_neurons, u_int16_t* offset);
-void get_output_num_corresponding_neurons_and_offset(const Gene* gene, u_int16_t* num_neurons, u_int16_t* offset);
+void get_source_num_corresponding_neurons_and_offset(const Gene* gene, uint16_t* num_neurons, uint16_t* offset);
+void get_output_num_corresponding_neurons_and_offset(const Gene* gene, uint16_t* num_neurons, uint16_t* offset);
 
 #endif // GENE_ENCODING_H


### PR DESCRIPTION
## Summary
- correct gene encoding helper declarations to use standard `uint16_t`
- link math library when building C simulation

## Testing
- `cd src/C && make clean && make`
- `timeout 5 ./simulation` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6895193eb744832ebcddbaaa5003308d