### PR TITLE
Add Windows compatibility to C Makefile

### DIFF
--- a/src/C/Makefile
+++ b/src/C/Makefile
@@ -1,11 +1,22 @@
+## Cross-platform Makefile
+
 # Compiler to use
 CC = gcc
 
 # Flags to pass to the compiler
 CFLAGS = -Wall -O2 -g
 
+# Detect Windows vs Unix-like systems
+ifeq ($(OS),Windows_NT)
+    EXT = .exe
+    RM = del /f
+else
+    EXT =
+    RM = rm -f
+endif
+
 # Target executable name
-TARGET = simulation
+TARGET = simulation$(EXT)
 
 # Source files
 SRCS = main.c grid.c neuron_encoding.c genetic_operations.c simulation.c gene_encoding.c
@@ -23,4 +34,4 @@ $(TARGET): $(OBJS)
 
 # Rule for cleaning up object files and target executable
 clean:
-	rm -f $(OBJS) $(TARGET)
+	$(RM) $(OBJS) $(TARGET)


### PR DESCRIPTION
## Summary
- make C build runnable on Windows by adding OS detection and .exe target extension
- use portable clean command via $(RM) for cross-platform cleanup

## Testing
- `make clean`
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68952669d38c832e81735966607e7762