### PR TITLE
Enable food-based learning and proper creature state updates

### DIFF
--- a/src/C/grid.c
+++ b/src/C/grid.c
@@ -86,3 +86,20 @@ int output_grid_to_csv(Grid* grid, const char* filename){
     fclose(file);
     return 0;
 }
+
+/**
+ * Scatter a number of food items randomly across the grid. Food is only placed
+ * in empty cells so it doesn't overwrite creatures or other items.
+ */
+void scatter_food(Grid* grid, uint32_t amount) {
+    uint32_t placed = 0;
+    while (placed < amount) {
+        uint16_t x = rand() % grid->width;
+        uint16_t y = rand() % grid->height;
+        Cell* cell = get_cell(grid, x, y);
+        if (!cell->flags.occupied && !cell->flags.food && !cell->flags.wall) {
+            cell->flags.food = 1;
+            placed++;
+        }
+    }
+}

--- a/src/C/grid.h
+++ b/src/C/grid.h
@@ -71,4 +71,12 @@ int output_grid_to_csv(Grid* grid, const char* filename);
 
 // ... Add any other utility functions or operations that should be supported by the grid.
 
+/**
+ * Scatter a number of food items randomly across the grid.
+ *
+ * @param grid Pointer to the grid.
+ * @param amount Number of food cells to place.
+ */
+void scatter_food(Grid* grid, uint32_t amount);
+
 #endif // GRID_H

--- a/src/C/simulation.h
+++ b/src/C/simulation.h
@@ -40,7 +40,7 @@ void spawn_creatures(Grid* grid, Creature* creatures);
  * @param grid Pointer to the grid containing the creature.
  * @param creature The creature to update.
  */
-void update_creature(Grid* grid, Creature creature);
+void update_creature(Grid* grid, Creature* creature);
 void spawn_creature(Creature* creature, int genome_length);
 /**
  * @brief Mates the creatures in the given grid.


### PR DESCRIPTION
## Summary
- Let creatures retain age and energy by updating them by reference
- Introduce food scattering and consumption to reward exploration
- Improve sensors to detect food and movement logic to eat it

## Testing
- `cd src/C && make clean && make`
- `cd src/C && timeout 5s ./simulation`


------
https://chatgpt.com/codex/tasks/task_e_68952b7d8e8c832eb547ac8de7a5feb1