### PR TITLE
Add screensaver playback script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ the C simulation.  The viewer now draws simple emojis, grid lines and a legend
 so it's clear where food, poison, water and creatures are located.  After the
 image is shown a short sentence is printed describing what each creature is
 doing.
+
+## Screensaver
+
+After generating a set of grid CSV snapshots for one generation, run
+
+```
+python src/Python/simulation/screensaver.py path/to/snapshots
+```
+
+The script loops through the frames endlessly so you can watch the creatures
+interact like a screen saver.

--- a/src/Python/simulation/screensaver.py
+++ b/src/Python/simulation/screensaver.py
@@ -1,0 +1,60 @@
+import argparse
+from pathlib import Path
+from typing import List
+
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+from .environment import Grid
+
+
+def load_grids(paths: List[Path]) -> List[Grid]:
+    """Load grid CSV files into :class:`Grid` objects."""
+    grids: List[Grid] = []
+    for path in paths:
+        grids.append(Grid.from_csv(path))
+    return grids
+
+
+def animate_grids(grids: List[Grid], interval: int) -> None:
+    """Animate a sequence of grids endlessly."""
+    images = [grid._to_image() for grid in grids]
+    fig, ax = plt.subplots()
+    im = ax.imshow(images[0], interpolation="none")
+    ax.axis("off")
+
+    def update(frame: int):
+        im.set_array(images[frame])
+        return [im]
+
+    FuncAnimation(fig, update, frames=len(images), interval=interval, repeat=True)
+    plt.show()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Play back a series of grid CSVs endlessly as a screen saver"
+    )
+    parser.add_argument(
+        "directory",
+        type=Path,
+        help="Directory containing grid CSV files for a single generation",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=200,
+        help="Delay between frames in milliseconds",
+    )
+    args = parser.parse_args()
+
+    csv_files = sorted(args.directory.glob("*.csv"))
+    if not csv_files:
+        raise SystemExit("No CSV files found in the specified directory")
+
+    grids = load_grids(csv_files)
+    animate_grids(grids, args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Introduce a screensaver utility that plays back a sequence of grid CSV files endlessly using Matplotlib animation
- Document screensaver usage in README

## Testing
- `python -m py_compile src/Python/simulation/screensaver.py`
- `python src/Python/simulation/screensaver.py --help` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68957d92174c832eb8efa0908085357c